### PR TITLE
Move state handling into the webserver

### DIFF
--- a/data/index.html
+++ b/data/index.html
@@ -105,30 +105,8 @@
                   tabindex="-1"
                 />
               </div>
-              <div
-                id="size-helper"
-                style="
-                  pointer-events: none;
-
-                  border-color: rgba(255, 166, 0, 0.4) rgba(0, 102, 255, 0.7);
-                  border-style: solid dashed solid dashed;
-
-                  border-width: 2px;
-                  mix-blend-mode: normal;
-
-                  margin: auto;
-                  /* margin-top: -2px; */
-                  background: #00000044;
-                  z-index: 50;
-                  font-size: 25px;
-                  height: 25px;
-                "
-              >
-                <div
-                  id="progress-bar"
-                  style="visibility: visible; background: white; height: 100%; width: 0%; mix-blend-mode: difference"
-                ></div>
-
+              <div id="size-helper">
+                <div id="progress-bar"></div>
                 <div id="size-helper-content" style="font-size: 25px; color: rgba(255, 0, 0, 0)">`WRITE HERE`</div>
               </div>
             </div>

--- a/data/style.css
+++ b/data/style.css
@@ -399,6 +399,40 @@ button:disabled {
   background: linear-gradient(rgb(11, 17, 26) 500px, rgb(3, 5, 8) 100%);
 }
 
+#size-helper {
+  border-style: solid dashed;
+  border-color: rgba(255, 166, 0, 0.4) rgba(0, 102, 255, 0.7);
+  background-color: rgba(0, 0, 0, 0);
+  mix-blend-mode: normal;
+  pointer-events: none;
+  border-width: 2px;
+  margin: auto;
+  background: #00000044;
+  z-index: 50;
+  font-size: 25px;
+  height: 25px;
+}
+
+[data-printing="true"] #size-helper {
+  border-color: rgba(128, 128, 128, 0);
+  border-style: solid;
+  background-color: rgba(32, 32, 32, 1);
+  mix-blend-mode: difference;
+}
+
+[data-printing="true"] #progress-bar {
+  visibility: visible; 
+  background: white; 
+  height: 100%; 
+  width: 0%; 
+  mix-blend-mode: difference
+}
+
+#progress-bar {
+  visibility: hidden; 
+  outline: none;
+}
+
 #frame {
   border-radius: 40px;
   /* filter: drop-shadow(-4px -4px 3px rgb(35, 42, 56)); */

--- a/platformio.ini
+++ b/platformio.ini
@@ -15,12 +15,11 @@ board = nodemcu-32s
 build_flags = -DASYNCWEBSERVER_REGEX
 monitor_speed = 115200
 monitor_filters = 
-	; debug
-	
 lib_deps = 
 	waspinator/AccelStepper@^1.61
 	madhephaestus/ESP32Servo@^0.9.0
-	ottowinter/ESPAsyncWebServer-esphome@^1.2.7
 	alanswx/ESPAsyncWiFiManager@^0.24
 	olikraus/U8g2@^2.28.8
 	ricmoo/QRCode@^0.0.1
+	bblanchon/ArduinoJson@^6.20.0
+	ottowinter/ESPAsyncWebServer-esphome@^3.0.0


### PR DESCRIPTION
The main goal of this PR is to fix issue #12, which it accomplishes by making the webserver report its current state (busy, command, etc) through a simple JSON API, so the browser is no longer responsible for determining when the printer is working.  This also allowed me to do some refactoring and simplification where it made sense in the context of my changes.  In particular I've:

- Removed the ```delay(500)``` from state changes (on the esp32) since the web-ui no longer requires it to show a consistent state.
- Consolidated the javascript logic that disables/enables input controls based on the "busy" state into a single method (to avoid duplication)
- Moved the UI properties for #progress-bar and #size-helper from javascript into CSS (they get changed based on data attribute selectors)
- Changed as much http request-based javascript as possible to use promises (ie the async/await/fetch syntax).
- Changed the javascript status polls to only make a new request after the previous one finishes, which prevents requests from queuing up and hammering the webserver during transient disconnections.
- Simplified the web server init code, which required updating the AsyncWebServer dependency.
- Added some TODO's for areas where I intend to add funtionality later

To the best of my ability this makes no change to the appearance or effective styling of the web interface.  One benefit of this PR is that if the page is refreshed while printing its printing status will still be reflected after the refresh, ie preventing you from submitting a label until the previous one finishes.  In such a case it won't show the proper label text, but I intend to address that in follow-up PR's as it requires more substantial refactoring to be done cleanly.