### PR TITLE
Note the prevChar is changed during homing

### DIFF
--- a/src/LabelMaker.cpp
+++ b/src/LabelMaker.cpp
@@ -740,6 +740,7 @@ void setHome(int align = alignFactor)
 	stepperChar.run();
 	stepperChar.setCurrentPosition(0);
 	currentCharPosition = charHome;
+	prevChar = charSet[charHome];
 
 	delay(100);
 }


### PR DESCRIPTION
Otherwise the printer can print the wrong character at the start of a print.
Fixes #18, and as an unintended side benefit if the first letter printed is the home character "J" then it avoids the need to home a second time to move into position.