### PR TITLE
Support UTF-8 and scroll longer labels on the screen

### DIFF
--- a/data/script.js
+++ b/data/script.js
@@ -135,15 +135,8 @@ function drawHelper() {
     document.getElementById("size-helper-content").innerHTML =
       space.repeat(multiplier) + "x".repeat(field.value.length) + space.repeat(multiplier);
 
-    treatedLabel = "_".repeat(multiplier) + field.value + "_".repeat(multiplier);
+    treatedLabel = " ".repeat(multiplier) + field.value + " ".repeat(multiplier);
     // console.log('"' + treatedLabel + '"');
-
-    // conversion table to prevent multichar error
-    treatedLabel = treatedLabel.replace(/♡/g, "<");
-    treatedLabel = treatedLabel.replace(/☆/g, ">");
-    treatedLabel = treatedLabel.replace(/♪/g, "~");
-    treatedLabel = treatedLabel.replace(/€/g, "|");
-    // console.log(treatedLabel);
   } else {
     clear = false;
     treatedLabel = "";


### PR DESCRIPTION
This PR:
 - Makes the E-TKT UTF-8 aware by parsing string contents to determine character position, length, etc
 - Uses the UTF-8 awareness to avoid substituting placeholder characters for the special characters it supports.
 - Makes the E-TKT scroll longer labels as its printing.
 - Renders special characters (♡, ☆, ♪, €) by picking and choosing different characters from different fonts for the best readability on the low-res screen.  Small rant: this was exactly as tedious as it sounds, but I think I did the best with what was available in U8g2lib.

Reviewer notes:
 - I would have normally to split this into two PR's, but the logic for rendering characters of different widths is pretty intermingled with the logic for scrolling the display, so I just made it all one.
 - The auto formatting seems to want to put the big  ```charSet``` map one line, which seems ugly to me but I didn't want to fight the formatter.


Since the website doesn't support printing labels long enough to trigger the screen scrolling (yet!) you can send labels using the command line, for example:
Linux (bash)
```bash
curl -vvv -X POST http://192.168.0.145/api/task -H 'Content-Type: application/json' -d '{"parameter":"tag", value:" This♡label☆is♪too€long@to$fit "}'
```

Windows (powershell)
```powershell
$data = @{'parameter'='tag';
          'value'=' This♡label☆is♪too€long@to$fit '
}
Invoke-WebRequest -Uri http://192.168.0.145/api/task -Method POST -Body ($data|ConvertTo-Json) -ContentType "application/json"
```