### PR TITLE
Add configuration to allow OTA updates

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -8,7 +8,7 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
-[env:nodemcu-32s]
+[env]
 platform = espressif32@3.3.2
 framework = arduino
 board = nodemcu-32s
@@ -23,3 +23,12 @@ lib_deps =
 	ricmoo/QRCode@^0.0.1
 	bblanchon/ArduinoJson@^6.20.0
 	ottowinter/ESPAsyncWebServer-esphome@^3.0.0
+	ayushsharma82/AsyncElegantOTA @ ^2.2.5
+
+[env:serial-upload]
+upload_protocol = esptool
+
+[env:ota-upload]
+extra_scripts = src/ota/upload.py
+upload_protocol = custom
+upload_url = http://e-tkt.local/update

--- a/src/LabelMaker.cpp
+++ b/src/LabelMaker.cpp
@@ -120,14 +120,14 @@ U8G2_SSD1306_128X64_NONAME_F_HW_I2C u8g2(U8G2_R0, U8X8_PIN_NONE);
 // DEBUG --------------------------------------------------------------------------
 // comment lines individually to isolate functions
 
-// #define do_cut
-// #define do_press
-// #define do_char
-// #define do_feed
+#define do_cut
+#define do_press
+#define do_char
+#define do_feed
 #define do_sound
 // #define do_wifi_debug
 // #define do_display_debug
-#define do_serial
+// #define do_serial
 
 // DATA ---------------------------------------------------------------------------
 

--- a/src/optConfig.cpp
+++ b/src/optConfig.cpp
@@ -15,3 +15,8 @@
 // For instance, invert if using a "3144" hall sensor but don't invert if using a "44E 402" hall sensor.
 
 // #define INVERT_HALL_SENSOR_LOGIC true
+
+// If you're developing for the E-TKT it might be useful to enable OTA updates for the board firmware and filesystem.  
+// Once firmware is uploaded with this option, you can use the env:ota-upload platformio target to upload to the device
+// over wifi. Alternatively, you can visit http://e-tkt.local/update to upload binaries manually.
+// #define OTA_ENABLED

--- a/src/ota/upload.py
+++ b/src/ota/upload.py
@@ -1,0 +1,50 @@
+# Allows PlatformIO to upload directly to AsyncElegantOTA
+# This script was copied form the AsyncelegantOTA github repo at:
+# https://github.com/ayushsharma82/AsyncElegantOTA
+# 
+# To use, set the following for your project in platformio.ini:
+#
+# extra_scripts = <path_to_this_script>
+# upload_protocol = custom
+# upload_url = http://e-tkt.local/update # or access by ip address
+
+import requests
+import hashlib
+Import('env')
+
+try:
+    from requests_toolbelt import MultipartEncoder, MultipartEncoderMonitor
+    from tqdm import tqdm
+except ImportError:
+    env.Execute("$PYTHONEXE -m pip install requests_toolbelt")
+    env.Execute("$PYTHONEXE -m pip install tqdm")
+    from requests_toolbelt import MultipartEncoder, MultipartEncoderMonitor
+    from tqdm import tqdm
+
+def on_upload(source, target, env):
+    firmware_path = str(source[0])
+    upload_url = env.GetProjectOption('upload_url')
+
+    with open(firmware_path, 'rb') as firmware:
+        md5 = hashlib.md5(firmware.read()).hexdigest()
+        firmware.seek(0)
+        encoder = MultipartEncoder(fields={
+            'MD5': md5, 
+            'firmware': ('firmware', firmware, 'application/octet-stream')}
+        )
+
+        bar = tqdm(desc='Upload Progress',
+              total=encoder.len,
+              dynamic_ncols=True,
+              unit='B',
+              unit_scale=True,
+              unit_divisor=1024
+              )
+
+        monitor = MultipartEncoderMonitor(encoder, lambda monitor: bar.update(monitor.bytes_read - bar.n))
+
+        response = requests.post(upload_url, data=monitor, headers={'Content-Type': monitor.content_type})
+        bar.close()
+        print(response,response.text)
+            
+env.Replace(UPLOADCMD=on_upload)


### PR DESCRIPTION
This adds some configuration I've been using for development, OTA uploading of the firmware and filesystem, because I frequently have my E-TKT physically distant from my development computer and also the soldering on my USB connector is not super rock solid.  I figured it might be useful for anyone else developing on this project in the future. OTA is accomplished by:

- Enabling a #define in the optional configuration, which causes [AsyncElegentOTA](https://github.com/ayushsharma82/AsyncElegantOTA) to hook into the webserver
- Adding mDNS config for the e-tkt
- Adding a special platformio target "upload-ota" that uploads firmware/filesystem over WiFi

To accomplish seamless upload, I've also configured the E-TKT to advertise itself and its webserver over mDNS along with some unique service text data in case anyone wants to automatically identify with automatic network discovery in the future.  The OTA upload script then uses the mDNS address to find the device, but of it can also be specified by IP address by modifying platformio.ini.  I've found the mDNS lookup works well on Windows and Linux, which is likely sufficient for development purposes. MacOS is likely to also work  but I can't test it.

To try out using OTA, you'd do the following:
 - Uncomment ```#define OTA_ENABLED``` in ```optConfig.cpp```
 - Connect the E-TKT over usb, and upload using either the default platformio environment or ```upload-serial```
 - Disconnect USB
 - Change plaformio target to ```upload-ota```
 - Enjoy wireless uploading of firmware and filesystem data.

Once enabled, you can also visit http://e-tkt.local/update to manually upload firmware/filesystem binaries.