### PR TITLE
Sync print label and progress across webapp instances

### DIFF
--- a/data/index.html
+++ b/data/index.html
@@ -116,6 +116,7 @@
                       spellcheck="false"
                       tabindex="-1"
                     />
+                    <div id="printing-label"></div>
                     <div id="progress-bar"></div>
                   </div>
                   <div class="overlay-gutter"></div>

--- a/data/script.js
+++ b/data/script.js
@@ -155,6 +155,10 @@ function getScrollbarHeight(element) {
   }
 }
 
+function getLabelWidth(element, label) {
+  return Math.max(measureText(element, label), measureText(element, " ".repeat(7))) + 4;
+}
+
 function drawHelper() {
   // draws visual helper with label length taking options into account
   const labelInput = document.getElementById("text-input");
@@ -169,11 +173,8 @@ function drawHelper() {
   document.getElementById("cut-button").disabled = !(labelText === "");
   document.getElementById("setup-button").disabled = !(labelText === "");
 
-  labelInput.style.width = measureText(labelInput, buildTreatedLabel()) + 4 + "px";
-  labelInput.style.minWidth = measureText(labelInput, " ".repeat(7)) + 4 + "px";
-
+  labelInput.style.width = getLabelWidth(labelInput, buildTreatedLabel()) + "px";
   const neededWidth = labelInput.clientWidth + 4;
-
   if (neededWidth > scroll.clientWidth) {
     // If modifying the text near the beginning or end of the scrollable area, then
     // move the scroll area to keep the border visible while editing for better context.
@@ -608,10 +609,12 @@ function handleData(data_json) {
       document.getElementById("submit-button").value = " printing " + percentage + "% ";
       let body = document.getElementsByTagName("body")[0];
       body.dataset.printing = "true";
-      const label = buildTreatedLabel();
-      const labelInput = document.getElementById("text-input");
+      const label = data_json.current_label || "unknown";
+      const printingLabel = document.getElementById("printing-label");
+      printingLabel.style.width = getLabelWidth(printingLabel, label) + "px";
+      printingLabel.innerHTML = label;
       const printed = label.substring(0, Math.round(label.length * (percentage / 100)));
-      const progressLength = measureText(labelInput, printed);
+      const progressLength = measureText(printingLabel, printed) + 3;
       document.getElementById("progress-bar").style.width = progressLength + "px";
 
       if (progressLength < scroll.clientWidth / 2) {

--- a/data/style.css
+++ b/data/style.css
@@ -328,9 +328,29 @@ button {
 }
 
 [data-printing="true"] #text-input {
-  box-shadow: none;
+  display: none;
+}
+
+#printing-label {
+  margin: auto;
+  grid-row-start: 1;
+  grid-column-start: 1;
+  height: 29px;
+  padding: 0px;
+  color: rgb(231, 218, 201);
+  box-shadow: 0px 0px 50px rgba(255, 255, 255, 0.5);
+  text-align: center;
+  font-size: 25px;
   border: solid transparent 2px;
   background: transparent;
+  display: none;
+  justify-content: center;
+  align-items: center;
+  white-space: pre;
+}
+
+[data-printing="true"] #printing-label {
+  display: flex;
 }
 
 #progress-bar {

--- a/src/LabelMaker.cpp
+++ b/src/LabelMaker.cpp
@@ -1476,9 +1476,11 @@ void getStatus(AsyncWebServerRequest *request)
 	root["align"] = alignFactor;
 	root["force"] = forceFactor;
 
-	// TODO: The webserver should also indicate what the text of the current,
-	// label is, however this will require substantial additional refactoring
-	// of how the current tag is communicated.
+	// Return the current label, if relevant.
+	if (parameter == "tag")
+	{
+		root["current_label"] = value;
+	}
 	response->setLength();
 	request->send(response);
 }

--- a/src/simulator/server.py
+++ b/src/simulator/server.py
@@ -42,13 +42,16 @@ class Server:
         return web.FileResponse(self.relativePath('../../data/index.html'))
 
     async def status(self, request):
-        return web.json_response({
+        resp = {
             'command': self.command,
             'progress': self.progress,
             'busy': self.busy,
             'force': self.force,
             'align': self.align
-        })
+        }
+        if self.command == "tag":
+            resp['current_label'] = self.value
+        return web.json_response(resp)
 
     async def task(self, request: web.Request):
         data = await request.json()


### PR DESCRIPTION
Returns the printing label as part of the status request and the webapp uses that to display printing progress even if it didn't start the print.  This means printing could interrupt a label you're currently editing, so I've made the "currently printing" label a separate element.  This allows the textbox comes back after printing with whatever you had in it.
I also updated the python server simulator to emulate the new behavior.